### PR TITLE
Fixed multi-page spells sometimes having page break in wrong place

### DIFF
--- a/src/components/CardFront.vue
+++ b/src/components/CardFront.vue
@@ -12,7 +12,9 @@ defineProps<IProps>()
 <template>
   <div class="front">
     <div class="body">
-      <h3 class="name lined srname">{{ spell.name }}</h3>
+      <h3 class="name lined srname" :class="{ small: spell.name.endsWith(']') }">
+        {{ spell.name }}
+      </h3>
 
       <div v-if="spell.castingTime != '' || spell.range != ''" class="status lined">
         <div><em>casting time</em>{{ spell.castingTime }}</div>
@@ -59,10 +61,11 @@ defineProps<IProps>()
   text-transform: uppercase;
   text-align: center;
   min-height: 20px;
+  font-weight: bold;
 }
 
-.srname {
-  font-weight: bold;
+.name.small {
+  font-size: 12px;
 }
 
 .status {

--- a/src/components/SpellSelectionWidget.vue
+++ b/src/components/SpellSelectionWidget.vue
@@ -136,6 +136,8 @@ function paginateText(text: string) {
 
   return paginatedText
 }
+
+paginateSpells()
 </script>
 
 <template>

--- a/src/models/SpellModel.ts
+++ b/src/models/SpellModel.ts
@@ -35,5 +35,17 @@ export const defaultSpells: SpellModel[] = [
     description: `A <em>bright</em> streak <i>flashes</i> from <b>your</b> pointing <strong>finger</strong> to a <mark>point</mark> you <s>choose</s> with<sub>i</sub>n <small>range</small> and then bl<sup>oss</sup>oms with a <q>low</q> roar<br>into an ex<wbr>plosion of <code>flame</code>. Each creature in a 20-foot radius sphere centered on that point must make a Dexterity saving throw. A target takes 8d6 fire damage on a failed save, or half as much damage on a successful one.<br>The fire spreads around corners. It ignites flammable objects in the area that aren't being worn or carried.<br><b>At Higher Levels</b>: When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot level above 3rd.`,
     source: 'Wizard',
     type: '3rd Level Evocation'
+  },
+  {
+    name: 'Meld into Stone (ritual)',
+    level: '3',
+    castingTime: '1 action',
+    range: '150 feet',
+    components: 'V, S, M',
+    duration: 'Instantaneous',
+    neededMaterials: 'A tiny ball of bat guano and sulfur',
+    description: `You step into a stone object or surface large enough to fully contain your body, melding yourself and all the equipment you carry with the stone for the duration. Using your movement, you step into the stone at a point you can touch. Nothing of your presence remains visible or otherwise detectable by nonmagical senses.<br> While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use your movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.<br> Minor physical damage to the stone doesn't harm you, but its partial destruction or a change in its shape (to the extent that you no longer fit within it) expels you and deals 6d6 bludgeoning damage to you. The stone's complete destruction (or transmutation into a different substance) expels you and deals 50 bludgeoning damage to you. If expelled, you fall prone in an unoccupied space closest to where you first entered.`,
+    source: 'Wizard',
+    type: '3rd Level Evocation'
   }
 ]


### PR DESCRIPTION
This fixes #1 
Fix issue with spell name overflowing on [X/N] addition to cause text cutoff to be in wrong place.

Problem:
When the addition of "[X/N]" causes the spell name to cover multiple lines, it changes the size of the description box, which had text specifically cutoff based on the previous size of the box. This causes overflow in the description:
![image](https://github.com/user-attachments/assets/19ab9373-a217-4493-8ef8-7a34a28afd94)

Solution:
As an easy fix for 90+% of cases, just make the spell name a bit smaller when the spell will have multiple pages (denoted by having "[X/N]", though the format only checks for titles ending in ']'):
![image](https://github.com/user-attachments/assets/3909697e-4e39-403f-afb4-bb1e19dccde7)

This works for [1/1] through [9/9] on both ends of the limit for a spell title to span another line. The issue will still occur in some cases if the spell description takes up a double-digit number of pages. A more elegant solution would be required to cover that scenario.