### PR TITLE
Fix issue with formatting on multi-page spells

### DIFF
--- a/src/components/SpellSelectionWidget.vue
+++ b/src/components/SpellSelectionWidget.vue
@@ -109,9 +109,21 @@ function paginateText(text: string) {
 
   currentPage.innerHTML = ''
 
-  const textArray = text.split(' ')
+  const textArray = text
+    .replace(new RegExp('([^ ])<', 'g'), '$1 <')
+    .replace(new RegExp('>([^ ])', 'g'), '> $1')
+    .split(' ')
+  const formatStack: string[] = []
   textArray.forEach((word) => {
-    if (!appendToPage(word)) {
+    if (word.startsWith('</')) {
+      formatStack.pop()
+      return
+    }
+    if (word.startsWith('<') && !['<br>', '<wbr>'].includes(word)) {
+      formatStack.push(word)
+      return
+    }
+    if (!appendToPage(formatStack.join('') + word)) {
       paginatedText.push(currentPage.innerHTML)
       currentPage.innerHTML = ''
       appendToPage(word)

--- a/src/models/SpellModel.ts
+++ b/src/models/SpellModel.ts
@@ -47,5 +47,17 @@ export const defaultSpells: SpellModel[] = [
     description: `You step into a stone object or surface large enough to fully contain your body, melding yourself and all the equipment you carry with the stone for the duration. Using your movement, you step into the stone at a point you can touch. Nothing of your presence remains visible or otherwise detectable by nonmagical senses.<br> While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use your movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.<br> Minor physical damage to the stone doesn't harm you, but its partial destruction or a change in its shape (to the extent that you no longer fit within it) expels you and deals 6d6 bludgeoning damage to you. The stone's complete destruction (or transmutation into a different substance) expels you and deals 50 bludgeoning damage to you. If expelled, you fall prone in an unoccupied space closest to where you first entered.`,
     source: 'Wizard',
     type: '3rd Level Evocation'
+  },
+  {
+    name: "Planar Binding",
+    level: "5",
+    castingTime: "1 hour",
+    range: "60 feet",
+    components: "V, S, M",
+    duration: "24 hours",
+    neededMaterials: "a jewel worth at least 1,000 gp, which the spell consumes",
+    description: `With <i><b>this</b></i> spell, you attempt to bind a celestial, an elemental, a fey, or a fiend to your service. The creature must be within range for the entire casting of the spell. (Typically, the creature is first summoned into the center of an inverted <i>magic circle</i> in order to keep it trapped while this spell is cast.) At the completion of the casting, the target must make a Charisma saving throw. On a failed save, it is bound to serve you for the duration. If the creature was summoned or created by another spell, that spell's duration is extended to match the duration of this spell.<br> A bound creature must follow your instructions to the best of its ability. You might command the creature to accompany you on an adventure, to guard a location, or to deliver a message. The creature obeys the letter of your instructions, but if the creature is hostile to you, it strives to twist your words to achieve its own objectives. If the creature carries out your instructions completely before the spell ends, it travels to you to report this fact if you are on the same plane of existence. If you are on a different plane of existence, it returns to the place where you bound it and remains there until the spell ends.<br> <b>At Higher Levels</b>: When you cast this spell using a spell slot of a higher level, the duration increases to 10 days with a 6th-level slot, to 30 days with a 7th-level slot, to 180 days with an 8th-level slot, and to a year and a day with a 9th-level spell slot.`,
+    source: "Cleric",
+    type: "5th level Abjuration"
   }
 ]


### PR DESCRIPTION
This fixes #2 

This fixes an issue in which multip-page spells have the formatting in non-void blocks applied to only the first word in the block. For example, all of "At Higher Levels:" should be bolded here, but only "At" is:
![image](https://github.com/user-attachments/assets/89e03832-14a9-4a6c-a10e-89f09f24d07f)

The problem is due to the way that text is added and rendered one word at a time while trying to determine how much text can fit on the card. Unclosed tags are automatically closed after the first render (which only has the first word), so the intended closing tag doesn't actually match where the enclosed text stops.

This fix works around the limitation by tracking the formatting (via a stack) and then applying the current formatting to the word being added, at each word addition. This results in the text being rendered properly, at the expense of each word having its own opening and closing tags.
![image](https://github.com/user-attachments/assets/c846835d-8d79-40c3-9723-6b03e46fbc01)
![image](https://github.com/user-attachments/assets/df9571ec-c676-4372-a719-8800bb0c1403)

While this works just fine, a better solution would likely require rethink and reworking the pagination process itself.